### PR TITLE
Switch to ament_cmake_ros_core package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -pthread)
 endif()
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 
 find_package(rmw REQUIRED)
 find_package(rmw_dds_common REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,8 @@
   <license>GPLv3</license>
 
   <buildtool_depend>rosidl_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>


### PR DESCRIPTION
This is a cherry-pick of signetlabdei/rmw_desert#2 to unblock buildfarm operations.

I will fast-forward merge this PR and export the patch once it has been approved.

FYI @dcostan